### PR TITLE
fixed glitch on ignore button in tattle-tale reports

### DIFF
--- a/seek_and_destroy/seek_and_destroy.pl
+++ b/seek_and_destroy/seek_and_destroy.pl
@@ -551,8 +551,15 @@ sub getTattleJSMagic
     {
         $("table").each(function()
         {
-            $(this).DataTable();
+           var dt = $(this).DataTable();
+           dt.on("draw",SetUpIgnore);
         });
+        SetUpIgnore();        
+    });
+
+
+    function SetUpIgnore()
+    {
         $(".ignorebutton").each(function()
         {
             var reportID = $(this).parents("table");
@@ -569,8 +576,8 @@ sub getTattleJSMagic
                 }
             }
         });
-    });
-
+    }
+    
     function handleIgnore(reportID, copyID)
     {
         var elements = getIgnoreButtonElements(reportID, copyID);


### PR DESCRIPTION
We found that the ignore buttons on the tattle tale reports were only functioning on the first page of each report. We fixed this by moving the ignore button setup into its own function and having that run on the datatable's "draw" event so that newly appearing buttons would get their events set up.